### PR TITLE
fix: make CI authoritative for eval results

### DIFF
--- a/Claude/CLAUDE.md
+++ b/Claude/CLAUDE.md
@@ -13,7 +13,8 @@ Each project should have its own `CLAUDE.md` at the repo root as the **micro** �
 2. Create a `CLAUDE.md` in the project root with project-specific details (micro)
 3. The micro `CLAUDE.md` should **not** duplicate macro rules — only add what's specific to that project
 4. Create a `features.md` in the project root — this is the **single source of truth** for all features (see [Feature Tracking](#feature-tracking) below)
-5. Set up a linter configuration appropriate to the project's language(s)
+5. Create an `evals.md` in the project root — this is the **single source of truth** for project eval contracts (see [Evals](#evals) below)
+6. Set up a linter configuration appropriate to the project's language(s)
 
 ---
 
@@ -46,6 +47,33 @@ Feature: <domain or category>
 - **Scenario** — one per feature; the scenario name is the feature name
 - **Given/When/Then** — describes the feature from the user's perspective
 - **Status** — tracked as `And the status is "..."` on the last line of each scenario
+
+---
+
+## Evals
+
+Every project **must** have an `evals.md` file at the repo root. This file is the **single source of truth** for eval contracts and their automated test mappings.
+
+Test runners and CI are the authoritative source for pass/fail results. Do not manually record transient eval statuses in `evals.md`.
+
+### Rules
+
+- **Create `evals.md` at project inception** — it should be one of the first files in any new project
+- **Always consult `evals.md` before implementing** — verify existing eval scenarios and identify gaps
+- **Update `evals.md` whenever behavior changes** — new features, bug fixes, and behavioral changes must update eval definitions and test mappings
+- **Never contradict `evals.md`** — if implementation and eval spec drift, align code to the spec (or update the spec first with the user's approval)
+- When I report a bug, don't start by trying to fix it. Instead, start by writing a test that reproduces the bug. Then have subagents try to fix the bug and prove it with a passing test.
+
+### Structure
+
+Each eval entry should include:
+
+- **Eval name** — short, descriptive title
+- **Description** — what behavior is validated and why it matters
+- **Test mapping** — automated test files or cases that enforce the contract, or the target feature/PR that will add them
+- **Notes** — relevant fixtures, thresholds, datasets, and execution details
+
+The exact format can be adapted per project, but every eval entry must at minimum have a name, description, and test mapping. Do not include a manually maintained status field.
 
 ---
 
@@ -214,6 +242,3 @@ Use these specialized agents (via the Task tool) for targeted work. Each agent r
 4. **Test** — use `senior-qa-engineer` to ensure coverage
 5. **Simplify** — use `code-simplification-architect` if the result is complex
 6. **Validate** — freeze the candidate at an immutable revision, then use `independent-validator` for evidence-backed validation
-
-### Bug Fixes
-When I report a bug, don't start by trying to fix it. Instead, start by writing a test that reproduces the bug. Then have subagents try to fix the bug and prove it with a passing test. 

--- a/Codex/AGENTS.md
+++ b/Codex/AGENTS.md
@@ -11,7 +11,7 @@ This file mirrors the macro development rules for Codex CLI usage (open-source a
 2. Create an `AGENTS.md` in the project root as the Codex mirror
 3. Keep this `AGENTS.md` aligned with `../Claude/CLAUDE.md`; do not diverge except for the skills/agents adaptation
 4. Create a `features.md` in the project root — this is the **single source of truth** for all features (see [Feature Tracking](#feature-tracking) below)
-5. Create an `evals.md` in the project root — this is the **single source of truth** for project evals (see [Evals](#evals) below)
+5. Create an `evals.md` in the project root — this is the **single source of truth** for project eval contracts (see [Evals](#evals) below)
 6. Set up a linter configuration appropriate to the project's language(s)
 
 ---
@@ -53,26 +53,28 @@ The exact format can be adapted per project, but every entry must at minimum hav
 
 ## Evals
 
-Every project **must** have an `evals.md` file at the repo root. This file is the **single source of truth** for eval coverage in the project.
+Every project **must** have an `evals.md` file at the repo root. This file is the **single source of truth** for eval contracts and their automated test mappings.
+
+Test runners and CI are the authoritative source for pass/fail results. Do not manually record transient eval statuses in `evals.md`.
 
 ### Rules
 
 - **Create `evals.md` at project inception** — it should be one of the first files in any new project
 - **Always consult `evals.md` before implementing** — verify existing eval scenarios and identify gaps
-- **Update `evals.md` whenever behavior changes** — new features, bug fixes, and behavioral changes must update eval definitions and status
+- **Update `evals.md` whenever behavior changes** — new features, bug fixes, and behavioral changes must update eval definitions and test mappings
 - **Never contradict `evals.md`** — if implementation and eval spec drift, align code to the spec (or update the spec first with the user's approval)
-- When I report a bug, don't start by trying to fix it. Instead, start by writing a test that reproduces the bug. Then have subagents try to fix the bug and prove it with a passing test. 
+- When I report a bug, don't start by trying to fix it. Instead, start by writing a test that reproduces the bug. Then have subagents try to fix the bug and prove it with a passing test.
 
 ### Structure
 
 Each eval entry should include:
 
 - **Eval name** — short, descriptive title
-- **Status** — e.g., `planned`, `in-progress`, `passing`, `failing`, `deprecated`
 - **Description** — what behavior is validated and why it matters
+- **Test mapping** — automated test files or cases that enforce the contract, or the target feature/PR that will add them
 - **Notes** — relevant fixtures, thresholds, datasets, and execution details
 
-The exact format can be adapted per project, but every eval entry must at minimum have a name, status, and description.
+The exact format can be adapted per project, but every eval entry must at minimum have a name, description, and test mapping. Do not include a manually maintained status field.
 
 ---
 

--- a/templates/common/evals.md
+++ b/templates/common/evals.md
@@ -1,22 +1,18 @@
 # Evals
 
-## Status Legend
-- `planned`
-- `in-progress`
-- `passing`
-- `failing`
-- `deprecated`
+This file defines stable evaluation contracts and their automated test mappings.
+Test runners and CI are the authoritative source for pass/fail results.
 
 ## Eval Template
 
 - Name:
-- Status:
 - Description:
+- Test mapping:
 - Notes:
 
 ## Example
 
 - Name: Core happy path returns expected result
-- Status: planned
 - Description: Validates the default user flow from input to successful completion.
-- Notes: Add fixtures for edge input once core flow is passing.
+- Test mapping: `tests/test_core_flow.py::test_core_happy_path`
+- Notes: Add fixtures for edge input as the contract grows.

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -107,6 +107,10 @@ test("init --agent both adds validator contracts without changing agent destinat
       (error) => error.code === "ENOENT"
     );
   }
+  const installedEvals = await fs.readFile(path.join(target, "evals.md"), "utf8");
+  assert.match(installedEvals, /- Test mapping:/);
+  assert.doesNotMatch(installedEvals, /^-\s+Status:/m);
+  assert.doesNotMatch(installedEvals, /Status Legend/);
   const installedChecker = require(
     path.join(
       target,


### PR DESCRIPTION
## Summary

- remove manually maintained eval status fields from the shared policy and generated template
- define evals.md as the stable contract and automated-test mapping catalog
- make test runners and CI authoritative for pass/fail results
- add an installer regression assertion that rejects Status fields and the old Status Legend

## Validation

- npm test: 31 passed
- git diff --check: passed